### PR TITLE
fix(StarMap): Skip ocean hexes for hex numbering but not hex position

### DIFF
--- a/src/Metadata.ts
+++ b/src/Metadata.ts
@@ -5,9 +5,9 @@ type Metadata = {
   "bottom-offset": number,
   "vertical-step": number,
   "horizontal-step": number,
-  "left-offset": any,
-  "row-length": any,
-  "special": any, 
+  "left-offset": Record<string, number>,
+  "row-length": Record<string, number>,
+  "special": Array<[number, number]>,
 }
 
 export default Metadata

--- a/src/StarMap.ts
+++ b/src/StarMap.ts
@@ -52,15 +52,24 @@ class StarMap {
       this.metadata = metadata;
     }).then(() => {
       if (this.metadata != null) {
+        const skipHex: Record<number, number> = {};
+        this.metadata.special.forEach((hex: [number, number]) => {
+          skipHex[hex[0]] = hex[1] - 1;
+        });
         for (let row = 1; row <= 71; row += 1) {
+          let skipCount = 0;
           for (let col = 0; col < this.metadata['row-length'][`${row}`]; col += 1) {
+            if (skipHex[row] === col) {
+              skipCount += 1;
+              continue;
+            }
             this.hexagons.push(new Hexagon(
               this.metadata['left-offset'][`${row}`] + col * this.metadata['horizontal-step'],
               this.metadata['bottom-offset'] + row * this.metadata['vertical-step'] - Math.round(this.metadata.flatten * row),
               10,
               10,
               row,
-              col + 1,
+              col + 1 - skipCount,
             ));
           }
         }


### PR DESCRIPTION
Paired with leonard-IMBERT/StarlightMap#19 which patches metadata values, otherwise this skips the wrong hex on row 43.

Use the 'special' field on metadata to skip entering the two ocean 'hexes'. This will correct numbering on rows 43 and 45. I've also added stricter types for metadata.